### PR TITLE
remove node max size option

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -12,8 +12,6 @@ jobs:
   GenerateCredInstance:
     runs-on: ubuntu-latest
     timeout-minutes: 720
-    env:
-      NODE_OPTIONS: --max_old_space_size=8192
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
While generating a new instance the workflow runs out of memory when trying to create to graph